### PR TITLE
Removes ability to assign duplicate packs

### DIFF
--- a/client/src/app/learners/learner-info/learner-info.component.spec.ts
+++ b/client/src/app/learners/learner-info/learner-info.component.spec.ts
@@ -65,6 +65,15 @@ describe('LearnerInfoComponent', () => {
     expect(component.id).toEqual('testLearner1');
   });
 
+  it('should not allow duplicate packs', () => {
+    const unchangedPacks = component.learner.assignedContextPacks;
+    component.ctxID = 'chris_id';
+    component.submitContextPackID();
+    component.submitContextPackID();
+    component.submitContextPackID();
+    expect(component.learner.assignedContextPacks).toEqual(unchangedPacks);
+  });
+
   it('should get assigned context packs', () => {
     component.getAssignedContextPacks();
     component.learner = {

--- a/client/src/app/learners/learner-info/learner-info.component.ts
+++ b/client/src/app/learners/learner-info/learner-info.component.ts
@@ -68,11 +68,18 @@ export class LearnerInfoComponent implements OnInit, OnDestroy {
 
 
   submitContextPackID(){
-
-    console.log(this.id);
-    console.log(this.ctxID);
+    let alreadyAssigned = false;
+    this.assignedPacks.forEach(pack => {
+      if(pack != null) {
+        if (pack._id === this.ctxID) {
+        alreadyAssigned = true;
+        }
+      }
+    });
+    if(!alreadyAssigned) {
     this.learnerService.addContextPackIdToLearner(this.ctxID, this.id).subscribe();
     window.location.reload();
+    }
   }
 }
 

--- a/client/src/app/learners/learner.service.ts
+++ b/client/src/app/learners/learner.service.ts
@@ -66,8 +66,6 @@ export class LearnerService {
   }
 
   addContextPackIdToLearner(idpack: string, id: string){
-    console.log(idpack);
-    console.log(id);
     return this.httpClient.post<{id: string}>(this.learnerUrl2 + '/' + id, '"'+idpack+'"').pipe(map(res => res.id));
   }
 


### PR DESCRIPTION
Changes submitcontextpackId so that learners cannot be assigned duplicate copies of a pack's ID, as well as adds a test to verify functionality